### PR TITLE
Updated method `-(void)addMarker: option:`

### DIFF
--- a/ios/RCTBaiduMap/RCTBaiduMapView.m
+++ b/ios/RCTBaiduMap/RCTBaiduMapView.m
@@ -91,8 +91,8 @@
 }
 
 -(void)addMarker:(BMKPointAnnotation *)annotation option:(NSDictionary *)option {
-    [self addAnnotation:annotation];
     [self updateMarker:annotation option:option];
+    [self addAnnotation:annotation];
 }
 
 -(void)updateMarker:(BMKPointAnnotation *)annotation option:(NSDictionary *)option {


### PR DESCRIPTION
In method `-(void)addMarker: option:`, you set annotation to map view first then updated the annotation. This may cause a problem which is map view 's delegate method `mapView: viewForAnnotation` called with an just initialized annotation. And there's no value in the annotation. 

People who want to customize annotation view would have no value to use, but the value is already in native code.