### PR TITLE
fixed bug: wrong SDK Build Tools revision

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,8 +13,8 @@ buildscript {
 }
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
The SDK Build Tools revision (23.0.2) is too low for project ':react-native-baidu-map'. Minimum required is 25.0.0