### PR TITLE
Fix PropTypes Bug In MapView.js

### DIFF
--- a/js/MapView.js
+++ b/js/MapView.js
@@ -5,12 +5,8 @@ import {
   Platform,
   DeviceEventEmitter
 } from 'react-native';
-
-import React, {
-  Component,
-  PropTypes
-} from 'react';
-
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import MapTypes from './MapTypes';
 
 export default class MapView extends Component {


### PR DESCRIPTION
"React.PropTypes has moved into a different package since React v15.5. Please use the prop-types library instead."