### PR TITLE
Allow gps conversion in Geolocation

### DIFF
--- a/android/src/main/java/org/lovebing/reactnative/baidumap/GeolocationModule.java
+++ b/android/src/main/java/org/lovebing/reactnative/baidumap/GeolocationModule.java
@@ -6,6 +6,7 @@ import com.baidu.location.BDLocation;
 import com.baidu.location.BDLocationListener;
 import com.baidu.location.LocationClient;
 import com.baidu.location.LocationClientOption;
+import com.baidu.location.LocationClientOption.LocationMode;
 import com.baidu.mapapi.model.LatLng;
 import com.baidu.mapapi.search.core.SearchResult;
 import com.baidu.mapapi.search.geocode.GeoCodeOption;
@@ -38,9 +39,9 @@ public class GeolocationModule extends BaseModule
         return "BaiduGeolocationModule";
     }
 
-
     private void initLocationClient() {
         LocationClientOption option = new LocationClientOption();
+        option.setLocationMode(LocationMode.Hight_Accuracy);
         option.setCoorType("bd09ll");
         option.setIsNeedAddress(true);
         option.setIsNeedAltitude(true);

--- a/android/src/main/java/org/lovebing/reactnative/baidumap/GeolocationModule.java
+++ b/android/src/main/java/org/lovebing/reactnative/baidumap/GeolocationModule.java
@@ -16,6 +16,7 @@ import com.baidu.mapapi.search.geocode.OnGetGeoCoderResultListener;
 import com.baidu.mapapi.search.geocode.ReverseGeoCodeOption;
 import com.baidu.mapapi.search.geocode.ReverseGeoCodeResult;
 import com.baidu.mapapi.utils.CoordinateConverter;
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactMethod;
@@ -77,6 +78,16 @@ public class GeolocationModule extends BaseModule
         LatLng desLatLng = converter.convert();
         return desLatLng;
 
+    }
+
+    @ReactMethod
+    public void convertGPSCoor(double lat, double lng, Promise promise) {
+        Log.i("convertGPSCoor", "convertGPSCoor");
+        LatLng latLng = getBaiduCoorFromGPSCoor(new LatLng(lat, lng));
+        WritableMap map = Arguments.createMap();
+        map.putDouble("latitude", latLng.latitude);
+        map.putDouble("longitude", latLng.longitude);
+        promise.resolve(map);
     }
 
     @ReactMethod

--- a/js/Geolocation.js
+++ b/js/Geolocation.js
@@ -28,6 +28,9 @@ export default {
       });
     });
   },
+  convertGPSCoor(lat, lng) {
+    return _module.convertGPSCoor(lat, lng);
+  },
   reverseGeoCode(lat, lng) {
     return new Promise((resolve, reject) => {
       try {


### PR DESCRIPTION
If the user is using a coordinate provider other than Geolocation, he should be able to convert its coordinate to the Baidu model.