### PR TITLE
react-native 0.59 版本下报错：Only one Looper may be created per thread

### DIFF
--- a/android/src/main/java/org/lovebing/reactnative/baidumap/BaiduMapPackage.java
+++ b/android/src/main/java/org/lovebing/reactnative/baidumap/BaiduMapPackage.java
@@ -56,7 +56,9 @@ public class BaiduMapPackage implements ReactPackage {
 
     @MainThread
     protected void init(ReactApplicationContext reactContext) {
-        Looper.prepare();
+        if (Looper.myLooper()==null){ 
+            Looper.prepare();
+        }
         SDKInitializer.initialize(reactContext.getApplicationContext());
     }
 }


### PR DESCRIPTION
react-native 0.59 版本下报错：Only one Looper may be created per thread