### PR TITLE
允许使用静态framework

### DIFF
--- a/ios/react-native-baidu-map.podspec
+++ b/ios/react-native-baidu-map.podspec
@@ -49,7 +49,7 @@ Pod::Spec.new do |s|
   # s.public_header_files = "**/*.h"
 
   s.frameworks = "CoreLocation", "QuartzCore", "OpenGLES", "SystemConfiguration", "CoreGraphics", "Security", "CoreTelephony" 
-
+  s.static_framework = true
   s.libraries = "c++", "sqlite3", "ssl", "crypto"
 
   # s.requires_arc = true


### PR DESCRIPTION
解决了`Podfile`使用 `  use_frameworks!`，动态库和静态库混用时，pod install 失败的问题