### PR TITLE
为 Android 版 Geolocation.getCurrentPosition 方法新增 coorType 属性支持，并修改为默认以 gcj02 坐标系返回

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ npm install react-native-baidu-map --save
 | Prop                    | Type  | Default  | Description
 | ----------------------- |:-----:| :-------:| -------
 | location                | object|{latitude: 0, longitude: 0}
-| visible                 | bool  | false    | 点击 marker 后才能设为 true 
+| visible                 | bool  | false    | 点击 marker 后才能设为 true
 
 ```jsx
 <MapView>
@@ -199,10 +199,10 @@ Cluster 示例
 
 #### Geolocation Methods
 
-| Method                    | Result
-| ------------------------- | -------
-| Promise reverseGeoCode(double lat, double lng) | `{"address": "", "province": "", "cityCode": "", "city": "", "district": "", "streetName": "", "streetNumber": ""}`
-| Promise reverseGeoCodeGPS(double lat, double lng) |  `{"address": "", "province": "", "cityCode": "", "city": "", "district": "", "streetName": "", "streetNumber": ""}`
-| Promise geocode(String city, String addr) | {"latitude": 0.0, "longitude": 0.0}
-| Promise getCurrentPosition() | iOS: `{"latitude": 0.0, "longitude": 0.0, "address": "", "province": "", "cityCode": "", "city": "", "district": "", "streetName": "", "streetNumber": ""}` Android: `{"latitude": 0.0, "longitude": 0.0, "direction": -1, "altitude": 0.0, "radius": 0.0, "address": "", "countryCode": "", "country": "", "province": "", "cityCode": "", "city": "", "district": "", "street": "", "streetNumber": "", "buildingId": "", "buildingName": ""}`
+| Method                    | Description | Result
+| ------------------------- | ---------------- | -------
+| Promise reverseGeoCode(double lat, double lng) | | `{"address": "", "province": "", "cityCode": "", "city": "", "district": "", "streetName": "", "streetNumber": ""}`
+| Promise reverseGeoCodeGPS(double lat, double lng) | |  `{"address": "", "province": "", "cityCode": "", "city": "", "district": "", "streetName": "", "streetNumber": ""}`
+| Promise geocode(String city, String addr) | | {"latitude": 0.0, "longitude": 0.0}
+| Promise getCurrentPosition(String coorType) | coorType 为可选参数，默认以 `gcj02` 坐标系，目前仅 Android 端支持使用 `BD09ll` | iOS: `{"latitude": 0.0, "longitude": 0.0, "address": "", "province": "", "cityCode": "", "city": "", "district": "", "streetName": "", "streetNumber": ""}` Android: `{"latitude": 0.0, "longitude": 0.0, "direction": -1, "altitude": 0.0, "radius": 0.0, "address": "", "countryCode": "", "country": "", "province": "", "cityCode": "", "city": "", "district": "", "street": "", "streetNumber": "", "buildingId": "", "buildingName": ""}`
 

--- a/android/src/main/java/org/lovebing/reactnative/baidumap/module/GeolocationModule.java
+++ b/android/src/main/java/org/lovebing/reactnative/baidumap/module/GeolocationModule.java
@@ -51,10 +51,10 @@ public class GeolocationModule extends BaseModule
         return "BaiduGeolocationModule";
     }
 
-    private void initLocationClient() {
+    private void initLocationClient(String coorType) {
         LocationClientOption option = new LocationClientOption();
         option.setLocationMode(LocationMode.Hight_Accuracy);
-        option.setCoorType("bd09ll");
+        option.setCoorType(coorType);
         option.setIsNeedAddress(true);
         option.setIsNeedAltitude(true);
         option.setIsNeedLocationDescribe(true);
@@ -102,9 +102,9 @@ public class GeolocationModule extends BaseModule
     }
 
     @ReactMethod
-    public void getCurrentPosition() {
+    public void getCurrentPosition(String coorType) {
         if(locationClient == null) {
-            initLocationClient();
+            initLocationClient(coorType);
         }
         Log.i("getCurrentPosition", "getCurrentPosition");
         locationClient.start();

--- a/js/Geolocation.js
+++ b/js/Geolocation.js
@@ -68,10 +68,10 @@ export default {
       });
     });
   },
-  getCurrentPosition() {
+  getCurrentPosition(coorType = 'gcj02') {
     return new Promise((resolve, reject) => {
       try {
-        _module.getCurrentPosition();
+        _module.getCurrentPosition(coorType);
       }
       catch (e) {
         reject(e);


### PR DESCRIPTION
这样的话，一方面和目前 iOS 版的该方法坐标系统一，另一方面和 [baidu-sdk 相关文档](http://lbsyun.baidu.com/index.php?title=android-locsdk/quick-start/term)契合。

百度定位SDK文档：

> 注意：百度Android定位SDK默认返回GCJ02坐标系，如您有需要，可以使用option.setCoorType（）选择您所需要的坐标系，或通过百度地图提供的坐标转换API服务切换为其他坐标系。

使用方法：
```
Geolocation.getCurrentPosition() // 默认为 GCJ02
// OR
Geolocation.getCurrentPosition('BD09ll') // 目前仅 Android 版支持
```