### PR TITLE
cluster模式下,不绘制视野外的marker。避免绘制大量marker发生卡顿。

### DIFF
--- a/android/src/main/java/com/baidu/mapapi/clusterutil/clustering/ClusterManager.java
+++ b/android/src/main/java/com/baidu/mapapi/clusterutil/clustering/ClusterManager.java
@@ -179,18 +179,32 @@ public class ClusterManager<T extends ClusterItem> implements
         }
 
         // Don't re-compute clusters if the map has just been panned/tilted/rotated.
-        MapStatus position = mMap.getMapStatus();
-        if (mPreviousCameraPosition != null && mPreviousCameraPosition.zoom == position.zoom) {
-            return;
-        }
-        mPreviousCameraPosition = mMap.getMapStatus();
+    //    MapStatus position = mMap.getMapStatus();
+    //    if (mPreviousCameraPosition != null && mPreviousCameraPosition.zoom == position.zoom) {
+    //        return;
+    //    }
+    //    mPreviousCameraPosition = mMap.getMapStatus();
 
-        cluster();
+    //    cluster();
     }
 
     @Override
     public void onMapStatusChangeFinish(MapStatus mapStatus) {
+        if (mRenderer instanceof BaiduMap.OnMapStatusChangeListener) {
+            ((BaiduMap.OnMapStatusChangeListener) mRenderer).onMapStatusChangeFinish(mapStatus);
+        }
 
+        // Don't re-compute clusters if the map has just been panned/tilted/rotated.
+//        MapStatus position = mMap.getMapStatus();
+//        if (mPreviousCameraPosition != null && mPreviousCameraPosition.zoom == position.zoom) {
+//            return;
+//        }
+//        if (mPreviousCameraPosition != null ) {
+//            return;
+//        }
+        mPreviousCameraPosition = mMap.getMapStatus();
+
+        cluster();
     }
 
     @Override

--- a/android/src/main/java/com/baidu/mapapi/clusterutil/clustering/ClusterManager.java
+++ b/android/src/main/java/com/baidu/mapapi/clusterutil/clustering/ClusterManager.java
@@ -177,15 +177,6 @@ public class ClusterManager<T extends ClusterItem> implements
         if (mRenderer instanceof BaiduMap.OnMapStatusChangeListener) {
             ((BaiduMap.OnMapStatusChangeListener) mRenderer).onMapStatusChange(mapStatus);
         }
-
-        // Don't re-compute clusters if the map has just been panned/tilted/rotated.
-    //    MapStatus position = mMap.getMapStatus();
-    //    if (mPreviousCameraPosition != null && mPreviousCameraPosition.zoom == position.zoom) {
-    //        return;
-    //    }
-    //    mPreviousCameraPosition = mMap.getMapStatus();
-
-    //    cluster();
     }
 
     @Override
@@ -194,14 +185,6 @@ public class ClusterManager<T extends ClusterItem> implements
             ((BaiduMap.OnMapStatusChangeListener) mRenderer).onMapStatusChangeFinish(mapStatus);
         }
 
-        // Don't re-compute clusters if the map has just been panned/tilted/rotated.
-//        MapStatus position = mMap.getMapStatus();
-//        if (mPreviousCameraPosition != null && mPreviousCameraPosition.zoom == position.zoom) {
-//            return;
-//        }
-//        if (mPreviousCameraPosition != null ) {
-//            return;
-//        }
         mPreviousCameraPosition = mMap.getMapStatus();
 
         cluster();

--- a/android/src/main/java/com/baidu/mapapi/clusterutil/clustering/view/DefaultClusterRenderer.java
+++ b/android/src/main/java/com/baidu/mapapi/clusterutil/clustering/view/DefaultClusterRenderer.java
@@ -325,10 +325,10 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements
 
         @SuppressLint("NewApi")
         public void run() {
-            if (clusters.equals(DefaultClusterRenderer.this.mClusters)) {
-                mCallback.run();
-                return;
-            }
+//            if (clusters.equals(DefaultClusterRenderer.this.mClusters)) {
+//                mCallback.run();
+//                return;
+//            }
 
             final MarkerModifier markerModifier = new MarkerModifier();
 
@@ -358,17 +358,19 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements
                     new ConcurrentHashMap<MarkerWithPosition, Boolean>());
             for (Cluster<T> c : clusters) {
                 boolean onScreen = visibleBounds.contains(c.getPosition());
-                if (zoomingIn && onScreen && SHOULD_ANIMATE) {
+                // if (zoomingIn && onScreen && SHOULD_ANIMATE) {
+                if ( onScreen ) {
                     Point point = mSphericalMercatorProjection.toPoint(c.getPosition());
                     Point closest = findClosestCluster(existingClustersOnScreen, point);
                     if (closest != null) {
                         LatLng animateTo = mSphericalMercatorProjection.toLatLng(closest);
-                        markerModifier.add(true, new CreateMarkerTask(c, newMarkers, animateTo));
+                        markerModifier.add(true, new CreateMarkerTask(c, newMarkers, SHOULD_ANIMATE ? animateTo : null));
                     } else {
                         markerModifier.add(true, new CreateMarkerTask(c, newMarkers, null));
                     }
                 } else {
-                    markerModifier.add(onScreen, new CreateMarkerTask(c, newMarkers, null));
+                    //todo
+//                    markerModifier.add(onScreen, new CreateMarkerTask(c, newMarkers, null));
                 }
             }
 

--- a/android/src/main/java/com/baidu/mapapi/clusterutil/clustering/view/DefaultClusterRenderer.java
+++ b/android/src/main/java/com/baidu/mapapi/clusterutil/clustering/view/DefaultClusterRenderer.java
@@ -325,11 +325,6 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements
 
         @SuppressLint("NewApi")
         public void run() {
-//            if (clusters.equals(DefaultClusterRenderer.this.mClusters)) {
-//                mCallback.run();
-//                return;
-//            }
-
             final MarkerModifier markerModifier = new MarkerModifier();
 
             final float zoom = mMapZoom;
@@ -358,7 +353,6 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements
                     new ConcurrentHashMap<MarkerWithPosition, Boolean>());
             for (Cluster<T> c : clusters) {
                 boolean onScreen = visibleBounds.contains(c.getPosition());
-                // if (zoomingIn && onScreen && SHOULD_ANIMATE) {
                 if ( onScreen ) {
                     Point point = mSphericalMercatorProjection.toPoint(c.getPosition());
                     Point closest = findClosestCluster(existingClustersOnScreen, point);
@@ -368,10 +362,7 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements
                     } else {
                         markerModifier.add(true, new CreateMarkerTask(c, newMarkers, null));
                     }
-                } else {
-                    //todo
-//                    markerModifier.add(onScreen, new CreateMarkerTask(c, newMarkers, null));
-                }
+                } 
             }
 
             // Wait for all markers to be added.

--- a/android/src/main/java/com/baidu/mapapi/clusterutil/clustering/view/DefaultClusterRenderer.java
+++ b/android/src/main/java/com/baidu/mapapi/clusterutil/clustering/view/DefaultClusterRenderer.java
@@ -353,7 +353,7 @@ public class DefaultClusterRenderer<T extends ClusterItem> implements
                     new ConcurrentHashMap<MarkerWithPosition, Boolean>());
             for (Cluster<T> c : clusters) {
                 boolean onScreen = visibleBounds.contains(c.getPosition());
-                if ( onScreen ) {
+                if (onScreen) {
                     Point point = mSphericalMercatorProjection.toPoint(c.getPosition());
                     Point closest = findClosestCluster(existingClustersOnScreen, point);
                     if (closest != null) {

--- a/android/src/main/java/org/lovebing/reactnative/baidumap/listener/MapListener.java
+++ b/android/src/main/java/org/lovebing/reactnative/baidumap/listener/MapListener.java
@@ -97,6 +97,9 @@ public class MapListener implements BaiduMap.OnMapStatusChangeListener,
     @Override
     public void onMapStatusChangeFinish(MapStatus mapStatus) {
         sendEvent(mapView, "onMapStatusChangeFinish", getEventParams(mapStatus));
+        for (BaiduMap.OnMapStatusChangeListener mapStatusChangeListener : mapStatusChangeListeners) {
+            mapStatusChangeListener.onMapStatusChangeFinish(mapStatus);
+        }
     }
 
     @Override


### PR DESCRIPTION
测试5000个marker聚合显示，在小米6上渲染流畅。
测试代码
```
<Overlay.Cluster>
                  {this.state.markers.map((marker, index) => <Overlay.Marker key={`marker-` + index} location={marker.location} />)}
                </Overlay.Cluster>
```